### PR TITLE
FORMIT-11649 Skip over migration check to load plugin manager

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,13 @@ class Main{
 
     //This migrates plugins from their previous git structure so clients stay in sync with latest plugin.
     migratePlugins(callback){
-        if (localStorage.getItem('hasMigrated')){
-            callback();
-            return;
+        try {
+            if (localStorage.getItem('hasMigrated')){
+                callback();
+                return;
+            }
+        } catch(e) {
+            console.log('Skipping hasMigrated check')
         }
 
         const migrationMap = {


### PR DESCRIPTION
The plugin manager calls localStorage which in incognito mode is inaccessible throwing an error, making plugin manager not load. This skips over that call if this happens.