### PR TITLE
Reverting work for 12249 until windows client install/load plugin broadcast is fixed

### DIFF
--- a/dev/components/appRoot.js
+++ b/dev/components/appRoot.js
@@ -316,10 +316,14 @@ class AppRoot extends React.Component {
         if (isInstalling){
             //TODO async/await wrappers
             //FormIt.InstallPlugin(pagesUrl);
-            FormItInterface.CallMethod("FormIt.InstallPlugin", pagesUrl);
+            FormItInterface.CallMethod("FormIt.InstallPlugin", pagesUrl, () => {
+                this.organizeToInstalledPlugins();
+            });
         }else{
             //FormIt.UninstallPlugin(pagesUrl);
-            FormItInterface.CallMethod("FormIt.UninstallPlugin", pagesUrl);
+            FormItInterface.CallMethod("FormIt.UninstallPlugin", pagesUrl, () => {
+                this.organizeToInstalledPlugins();
+            });
         }
     }
 

--- a/dev/components/installPluginControls.js
+++ b/dev/components/installPluginControls.js
@@ -6,39 +6,6 @@ class InstallPluginControls extends React.Component {
         this.state = {
             isOpen: this.props.isOpen
         };
-
-        FormItInterface.SubscribeMessage("FormIt.Message.kInstallPlugin", (installedPlugin) => {
-            if (this.state.installUrl.startsWith(installedPlugin)) {
-                this.setState({installUrl: ''});
-                if(this.notificationHandle)
-                    FormIt.UI.CloseNotification(this.notificationHandle);
-                FormIt.UI.ShowNotification(
-                    "Plugin installed.",
-                    FormIt.NotificationType.Success,
-                    3000
-                );
-            }
-        });
-    }
-
-    notificationHandle
-
-    async showLoadingMessage(isLoading = false) {
-        let copyInstallUrl = this.state.installUrl
-        this.notificationHandle = await FormIt.UI.ShowNotification(
-            "Attempting to install plugin...",
-            FormIt.NotificationType.Information,
-            5000
-        );
-        setTimeout(() => {
-            if(this.state.installUrl == copyInstallUrl) {
-                FormIt.UI.ShowNotification(
-                    `Failed to ${isLoading ? 'load' : 'install'} plugin. Check your internet connection or ${FormItInterface.Platform == 'Windows' ? 'Script Editor' : 'console'} for errors.`,
-                    FormIt.NotificationType.Error,
-                    10000
-                );
-            }
-        }, 5000);
     }
 
     render(){
@@ -74,7 +41,7 @@ class InstallPluginControls extends React.Component {
                         onClick: () => {
                             if (this.state.installUrl){
                                 this.props.addPlugin(this.state.installUrl);
-                                this.showLoadingMessage();
+                                this.setState({installUrl: ''});
                             }
                         },
                         title:'Add'

--- a/dev/index.html
+++ b/dev/index.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/FormIt.js"></script>
     <script type="text/javascript" src="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/FormItPluginUI.js"></script>
     <link rel="stylesheet" type="text/css" href="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/FormItPluginStyling.css">
-    <script type="text/javascript" src="https://formit3d.github.io/SharedPluginUtilities/v23_0/FormItInterface.js"></script>
+    <script type="text/javascript" src="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/FormItInterface.js"></script>
     <script type="text/javascript" src="https://formit3d.github.io/FormItExamplePlugins/SharedPluginFiles/PluginUtils.js"></script>
 
     <script src="https://kit.fontawesome.com/c35c0bb2dc.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
Revert "FORMIT-12249 Uses the fixed callback output of SubscribeMessage in web (#37)"

This reverts commit 50007b4e4d5782818f970411ca94da23722eca51.

Revert "FORMIT-12249 Removes alert for loading plugin ... (#33)"

This reverts commit 52e25a593f7fde2a6dc9d57fb1bbf57b5ac65020.

Revert "FORMIT-12249 Clear install/load input only if plugin url was installed/loaded (#32)"

This reverts commit 7ad21870892ed44ff16a65f6d6af198822e925b3.